### PR TITLE
Adhere to max_length property

### DIFF
--- a/lib/acts_as_permalink.rb
+++ b/lib/acts_as_permalink.rb
@@ -8,10 +8,10 @@ module Acts #:nodoc:
 
     module ClassMethods
       def acts_as_permalink(options={})
-        # Read and scrub option for the column which will save the permalink    
+        # Read and scrub option for the column which will save the permalink
         self.base_class.instance_variable_set('@permalink_column_name', options[:to].try(:to_sym) || :permalink)
 
-        # Read and scrub the option for the column or function which will generate the permalink 
+        # Read and scrub the option for the column or function which will generate the permalink
         self.base_class.instance_variable_set('@permalink_source', (options[:from].try(:to_sym) || :title))
 
         # Read and validate the maximum length of the permalink
@@ -20,24 +20,24 @@ module Acts #:nodoc:
         self.base_class.instance_variable_set('@permalink_length', max_length)
 
         if Rails.version >= "3"
-          before_validation :update_permalink, :on => :create
+          before_validation :update_permalink, on: :create
         else
           before_validation_on_create :update_permalink
         end
 
         validates_uniqueness_of @permalink_column_name
         attr_readonly @permalink_column_name
-        
+
         include Acts::Permalink::InstanceMethods
         extend Acts::Permalink::SingletonMethods
       end
-      
+
       # Returns the unique permalink string for the passed in object.
       def generate_permalink_for(obj)
-
-        # Find the source for the permalink
+        column_name = obj.class.base_class.instance_variable_get('@permalink_column_name')
         text = obj.send(obj.class.base_class.instance_variable_get('@permalink_source'))
-        
+        max_length = obj.class.base_class.instance_variable_get('@permalink_length')
+
         # If it is blank then generate a random link
         if text.blank?
           text = obj.class.base_class.to_s.downcase + rand(10000).to_s
@@ -47,37 +47,39 @@ module Acts #:nodoc:
           text = text.downcase.strip                  # make the string lowercase and scrub white space on either side
           text = text.gsub(/[^a-z0-9\w]/, "_")        # make any character that is not nupermic or alphabetic into an underscore
           text = text.sub(/_+$/, "").sub(/^_+/, "")   # remove underscores on either end, caused by non-simplified characters
-          text = text[0...obj.class.base_class.instance_variable_get('@permalink_length')]        # trim to length
+          text = text[0...max_length]                 # trim to length
         end
-        
-        # Attempt to find the object by the permalink
-        if obj.class.base_class.send("find_by_#{obj.class.base_class.instance_variable_get('@permalink_column_name')}", text)
-          num = 1
 
-          # If we find the object we know there is a collision, so just add a number to the end until there is no collision
-          while obj.class.base_class.send("find_by_#{obj.class.base_class.instance_variable_get('@permalink_column_name')}", text + num.to_s)
-            num += 1
+        # Attempt to find the object by the permalink, and if so there is a collision and we need to de-collision it
+        if obj.class.base_class.where(column_name => text).first
+          candidate_text = nil
+
+          (1..999999).each do |num|
+            suffix = "-#{ num }"
+            candidate_text = [text[0...(max_length - suffix.length)], suffix].join("")
+            break unless obj.class.base_class.where(column_name => candidate_text).first
           end
 
-          text = text + num.to_s
+          text = candidate_text
         end
+
         text
       end
     end
-  
+
     module SingletonMethods
     end
-    
+
     module InstanceMethods
 
       # Override this method so that find searches by permalink and not by id
       def to_param
         self.send(self.class.base_class.instance_variable_get('@permalink_column_name'))
       end
-      
+
       # Generate the permalink and assign it directly via callback
       def update_permalink
-        self.send("#{self.class.base_class.instance_variable_get('@permalink_column_name')}=", self.class.base_class.generate_permalink_for(self))
+        self.send("#{ self.class.base_class.instance_variable_get('@permalink_column_name') }=", self.class.base_class.generate_permalink_for(self))
         true
       end
     end

--- a/lib/acts_as_permalink/version.rb
+++ b/lib/acts_as_permalink/version.rb
@@ -1,5 +1,5 @@
 module Acts
   module Permalink
-    VERSION = "0.4.2"
+    VERSION = "0.5.0"
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -17,3 +17,10 @@ ActiveRecord::Base.connection.create_table(:things) do |t|
   t.string :permalink
   t.string :type
 end
+
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'long_things'")
+ActiveRecord::Base.connection.create_table(:long_things) do |t|
+  t.string :title
+  t.string :permalink
+  t.string :type
+end


### PR DESCRIPTION
Fixes a few things:

* Actually adheres to the `max_length` property when adding a numeric suffix on collision. Before it would just add it to the end and be longer.
* Use `where().first` over `send("find_by_#{ column }")`.
* Refactors some readability problems.
* Bumps to `0.5.0`.
* Improves test coverage.
* New hash syntax. (Initial commit for this was 2009!) 