### PR TITLE
Refactor and v 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.2.1"
 script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Or stand alone:
 $ gem install acts_as_permalink
 ```
 
+## Requirements
+
+* Ruby 2.0 or higher
+* Rails 4.0 or higher
+
+
 ## Usage
 
 This gem works with ActiveRecord, and by convention looks for a `title` method and a `permalink` string field on the model:
@@ -67,6 +73,8 @@ $ bundle exec rspec
 
 
 ## Changelog
+
+* 1.0.0  --  Internal refactor. Require Rails 4.0 or above and Ruby 2.0 or above. Full release, only took 6 years!
 
 * 0.6.0  --  Switch default replacement character to a dash, but allow the `underscore: true` property to go back to the old format
 

--- a/acts_as_permalink.gemspec
+++ b/acts_as_permalink.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
 
-  s.add_dependency "rails", ">= 3.0"
+  s.add_dependency "rails", ">= 4.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "sqlite3"

--- a/lib/acts_as_permalink.rb
+++ b/lib/acts_as_permalink.rb
@@ -14,30 +14,6 @@ module Acts
         validates_uniqueness_of self.acts_as_permalink_config.to
         attr_readonly self.acts_as_permalink_config.to
       end
-
-      def generate_permalink_for(obj)
-        config = obj.class.base_class.acts_as_permalink_config
-
-        text = obj.public_send(config.from)
-        text = [obj.class.base_class.to_s, rand(10000)].join(config.separator) if text.blank?
-        text = text.to_permalink(separator: config.separator, max_length: config.max_length)
-
-        # Attempt to find the object by the permalink, and if so there is a collision and we need to de-collision it
-        if obj.class.base_class.where(config.to => text).first
-          candidate_text = nil
-
-          # This will fail if you have a million records with the same name
-          (1..999999).each do |num|
-            suffix = "#{ config.separator }#{ num }"
-            candidate_text = [text[0...(config.max_length - suffix.length)], suffix].join("")
-            break unless obj.class.base_class.where(config.to => candidate_text).first
-          end
-
-          text = candidate_text
-        end
-
-        text
-      end
     end
 
     included do
@@ -46,8 +22,32 @@ module Acts
       end
 
       def update_permalink
-        self.public_send("#{ self.class.base_class.acts_as_permalink_config.to }=", self.class.base_class.generate_permalink_for(self))
+        self.public_send("#{ self.class.base_class.acts_as_permalink_config.to }=", build_permalink)
         true
+      end
+
+      def build_permalink
+        config = self.class.base_class.acts_as_permalink_config
+
+        text = self.public_send(config.from)
+        text = [self.class.base_class.to_s, rand(10000)].join(config.separator) if text.blank?
+        text = text.to_permalink(separator: config.separator, max_length: config.max_length)
+
+        # Attempt to find the object by the permalink, and if so there is a collision and we need to de-collision it
+        if self.class.base_class.where(config.to => text).first
+          candidate_text = nil
+
+          # This will fail if you have a million records with the same name
+          (1..999999).each do |num|
+            suffix = "#{ config.separator }#{ num }"
+            candidate_text = [text[0...(config.max_length - suffix.length)], suffix].join("")
+            break unless self.class.base_class.where(config.to => candidate_text).first
+          end
+
+          text = candidate_text
+        end
+
+        text
       end
     end
 

--- a/lib/acts_as_permalink.rb
+++ b/lib/acts_as_permalink.rb
@@ -1,69 +1,36 @@
-# ActsAsPermalink
-module Acts #:nodoc:
-  module Permalink #:nodoc:
+require "string"
+require "config"
 
-    def self.included(base)
-      base.extend ClassMethods
-    end
+module Acts
+  module Permalink
+    extend ActiveSupport::Concern
 
-    module ClassMethods
+    class_methods do
       def acts_as_permalink(options={})
-        # Read and scrub option for the column which will save the permalink
-        self.base_class.instance_variable_set('@permalink_column_name', options[:to].try(:to_sym) || :permalink)
+        cattr_accessor :acts_as_permalink_config
+        self.acts_as_permalink_config = Acts::Permalink::Config.new(options)
 
-        # Read and scrub the option for the column or function which will generate the permalink
-        self.base_class.instance_variable_set('@permalink_source', (options[:from].try(:to_sym) || :title))
-
-        # Set the underscore character
-        self.base_class.instance_variable_set('@permalink_underscore', options[:underscore])
-
-        # Read and validate the maximum length of the permalink
-        max_length = options[:max_length].to_i rescue 0
-        max_length = 60 unless max_length && max_length > 0
-        self.base_class.instance_variable_set('@permalink_length', max_length)
-
-        if Rails.version >= "3"
-          before_validation :update_permalink, on: :create
-        else
-          before_validation_on_create :update_permalink
-        end
-
-        validates_uniqueness_of @permalink_column_name
-        attr_readonly @permalink_column_name
-
-        include Acts::Permalink::InstanceMethods
-        extend Acts::Permalink::SingletonMethods
+        before_validation :update_permalink, on: :create
+        validates_uniqueness_of self.acts_as_permalink_config.to
+        attr_readonly self.acts_as_permalink_config.to
       end
 
-      # Returns the unique permalink string for the passed in object.
       def generate_permalink_for(obj)
-        column_name = obj.class.base_class.instance_variable_get('@permalink_column_name')
-        text = obj.send(obj.class.base_class.instance_variable_get('@permalink_source'))
-        max_length = obj.class.base_class.instance_variable_get('@permalink_length')
-        separator = obj.class.base_class.instance_variable_get('@permalink_underscore') ? "_" : "-"
+        config = obj.class.base_class.acts_as_permalink_config
 
-        # If it is blank then generate a random link
-        if text.blank?
-          text = obj.class.base_class.to_s.downcase + rand(10000).to_s
-
-        # If it is not blank, scrub
-        else
-          text = text.downcase.strip                  # make the string lowercase and scrub white space on either side
-          text = text.gsub(/[^a-z0-9\w]/, separator)  # make any character that is not nupermic or alphabetic into a special character
-          text = text.squeeze(separator)              # removes any consecutive duplicates of the special character
-          text = text[0...max_length]                 # trim to length
-          text = text.sub(Regexp.new("^#{ separator }+"), "")  # remove leading special characters
-          text = text.sub(Regexp.new("#{ separator }+$"), "")  # remove trailing special characters
-        end
+        text = obj.public_send(config.from)
+        text = [obj.class.base_class.to_s, rand(10000)].join(config.separator) if text.blank?
+        text = text.to_permalink(separator: config.separator, max_length: config.max_length)
 
         # Attempt to find the object by the permalink, and if so there is a collision and we need to de-collision it
-        if obj.class.base_class.where(column_name => text).first
+        if obj.class.base_class.where(config.to => text).first
           candidate_text = nil
 
+          # This will fail if you have a million records with the same name
           (1..999999).each do |num|
-            suffix = "#{ separator }#{ num }"
-            candidate_text = [text[0...(max_length - suffix.length)], suffix].join("")
-            break unless obj.class.base_class.where(column_name => candidate_text).first
+            suffix = "#{ config.separator }#{ num }"
+            candidate_text = [text[0...(config.max_length - suffix.length)], suffix].join("")
+            break unless obj.class.base_class.where(config.to => candidate_text).first
           end
 
           text = candidate_text
@@ -73,22 +40,17 @@ module Acts #:nodoc:
       end
     end
 
-    module SingletonMethods
-    end
-
-    module InstanceMethods
-
-      # Override this method so that find searches by permalink and not by id
+    included do
       def to_param
-        self.send(self.class.base_class.instance_variable_get('@permalink_column_name'))
+        self.public_send(self.class.base_class.acts_as_permalink_config.to)
       end
 
-      # Generate the permalink and assign it directly via callback
       def update_permalink
-        self.send("#{ self.class.base_class.instance_variable_get('@permalink_column_name') }=", self.class.base_class.generate_permalink_for(self))
+        self.public_send("#{ self.class.base_class.acts_as_permalink_config.to }=", self.class.base_class.generate_permalink_for(self))
         true
       end
     end
+
   end
 end
 

--- a/lib/acts_as_permalink/version.rb
+++ b/lib/acts_as_permalink/version.rb
@@ -1,5 +1,5 @@
 module Acts
   module Permalink
-    VERSION = "0.6.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,7 +11,7 @@ module Acts
         @separator = @config[:underscore] ? "_" : "-"
 
         @max_length = @config[:max_length].to_i rescue 0
-        @max_length = 60 unless @max_length && @max_length > 0
+        @max_length = 60 unless @max_length > 0
       end
     end
   end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,18 @@
+module Acts
+  module Permalink
+    class Config
+      attr_reader :to, :from, :separator, :max_length
+
+      def initialize(options={})
+        @config = options.with_indifferent_access
+
+        @to = @config[:to].try(:to_sym) || :permalink
+        @from = @config[:from].try(:to_sym) || :title
+        @separator = @config[:underscore] ? "_" : "-"
+
+        @max_length = @config[:max_length].to_i rescue 0
+        @max_length = 60 unless @max_length && @max_length > 0
+      end
+    end
+  end
+end

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -1,0 +1,14 @@
+class String
+  def to_permalink(max_length: nil, separator: "-")
+    text = self.dup
+
+    text = text.downcase.strip                           # make the string lowercase and scrub white space on either side
+    text = text.gsub(/[^a-z0-9]/, separator)             # make any character that is not nupermic or alphabetic into a special character
+    text = text.squeeze(separator)                       # removes any consecutive duplicates of the special character
+    text = text.sub(Regexp.new("^#{ separator }+"), "")  # remove leading special characters
+    text = text.sub(Regexp.new("#{ separator }+$"), "")  # remove trailing special characters
+    text = text[0...max_length] if max_length            # trim to length
+
+    text
+  end
+end

--- a/spec/lib/acts_as_permalink_spec.rb
+++ b/spec/lib/acts_as_permalink_spec.rb
@@ -36,6 +36,11 @@ describe Acts::Permalink do
       expect(record.permalink).to eq("#{ "b" * 58 }-1")
     end
 
+    it "makes a random permalink if the source is blank" do
+      record = Post.create!(title: "")
+      expect(record.permalink).to_not be_blank
+      expect(record.permalink).to match(/^post-\d+$/)
+    end
   end
 
   describe "column with some custom properties" do
@@ -89,7 +94,7 @@ describe Acts::Permalink do
     end
 
     it "works for custom attributes" do
-      record = OtherPost.new other_title: "Other post"
+      record = OtherPost.new(other_title: "Other post")
       expect(record.other_permalink).to be_nil
       record.save!
       expect(record.permalink).to be_nil

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Acts::Permalink::Config do
+  it "has defaults" do
+    config = Acts::Permalink::Config.new
+
+    expect(config.to).to eq(:permalink)
+    expect(config.from).to eq(:title)
+    expect(config.separator).to eq("-")
+    expect(config.max_length).to eq(60)
+  end
+
+  it "allows the underscore property" do
+    expect(Acts::Permalink::Config.new(underscore: true).separator).to eq("_")
+  end
+
+  it "allows indifferent access" do
+    config = Acts::Permalink::Config.new("underscore" => true, "max_length" => "10")
+
+    expect(config.separator).to eq("_")
+    expect(config.max_length).to eq(10)
+  end
+
+  it "overrides the columns" do
+    config = Acts::Permalink::Config.new(to: :to_column, from: "from_column")
+
+    expect(config.to).to eq(:to_column)
+    expect(config.from).to eq(:from_column)
+  end
+
+  it "max_length checks for numbers and allows defaults with bad data" do
+    expect(Acts::Permalink::Config.new(max_length: -1).max_length).to eq(60)
+    expect(Acts::Permalink::Config.new(max_length: "asdf").max_length).to eq(60)
+    expect(Acts::Permalink::Config.new(max_length: 666).max_length).to eq(666)
+    expect(Acts::Permalink::Config.new(max_length: "666").max_length).to eq(666)
+  end
+end

--- a/spec/lib/string_spec.rb
+++ b/spec/lib/string_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe String do
+  describe "#to_permalink" do
+    it "converts a string to a permalink" do
+      expect("it's a wonderful day!!".to_permalink).to eq("it-s-a-wonderful-day")
+      expect("@$#a{$%^b#$%#%c!@<>d,./".to_permalink).to eq("a-b-c-d")
+    end
+
+    it "allows overriding the separator" do
+      expect("(Oh hey neat), an underscore __ character".to_permalink(separator: "_")).to eq("oh_hey_neat_an_underscore_character")
+    end
+
+    it "allows defining a max length" do
+      expect("_-_-_-123456_-_-_-_".to_permalink(max_length: 3)).to eq("123")
+    end
+  end
+end


### PR DESCRIPTION
@garethson

Basically a full refactor. Releasing version 1.0.0 after 6 years!

* Extract permalink generation into `String#to_permalink` patch.
* Create a `Config` class to store concerns, and put that in a single class variable rather than class instance variables.
* Use `public_send` over `send`.
* Require at least Ruby 2.0.
* Require at least Rails 4.0.
* Use `ActiveSupport::Concern`.
* Refactor main class macro to be way more readable and use all the above things.