### PR TITLE
Permalink by scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ The `title` and `permalink` fields can be overridden with the following options:
     to:          :permalink   # Name of the column where the permalink will be stored
     max_length:  60           # Maximum number of characters the permalink will be
     underscore:  false        # Prefer using the `_` character as a replacement over the default `-`
+    scope:       nil          # Make the permalink unique scoped to a particular attribute
 
-So, for example you have want to store your permalink in a column called `path_name` and you want to generate your permalink using first and last name, and you want to restrict it to 40 characters, your model would look like:
+So, for example you have want to store your permalink in a column called `path_name` and you want to generate your permalink using first and last name, and you want to restrict it to 40 characters, and scope the permalink by organization, your model would look like:
 
 ```ruby
 class User < ActiveRecord::Base
-  acts_as_permalink from: :full_name, to: :path, max_length: 40
+  acts_as_permalink from: :full_name, to: :path, max_length: 40, scope: :organization_id
+
+  belongs_to :organization
 
   def full_name
     [first_name, last_name].join(" ")
@@ -73,6 +76,8 @@ $ bundle exec rspec
 
 
 ## Changelog
+
+* 1.1.0  --  Allow the option to `scope: :column_id` for uniquness.
 
 * 1.0.3  --  Update tests to use DatabaseCleaner, and bump some dependency versions.
 

--- a/lib/acts_as_permalink/version.rb
+++ b/lib/acts_as_permalink/version.rb
@@ -1,5 +1,5 @@
 module Acts
   module Permalink
-    VERSION = "1.0.3"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,7 +1,7 @@
 module Acts
   module Permalink
     class Config
-      attr_reader :to, :from, :separator, :max_length
+      attr_reader :to, :from, :separator, :max_length, :scope
 
       def initialize(options={})
         @config = options.with_indifferent_access
@@ -9,6 +9,7 @@ module Acts
         @to = @config[:to].try(:to_sym) || :permalink
         @from = @config[:from].try(:to_sym) || :title
         @separator = @config[:underscore] ? "_" : "-"
+        @scope = @config[:scope].presence
 
         @max_length = @config[:max_length].to_i rescue 0
         @max_length = 60 unless @max_length > 0

--- a/spec/lib/acts_as_permalink_spec.rb
+++ b/spec/lib/acts_as_permalink_spec.rb
@@ -111,4 +111,33 @@ describe Acts::Permalink do
     end
   end
 
+  describe "scope and validation" do
+    class Event < ActiveRecord::Base
+      acts_as_permalink
+      validates :description, :title, presence: true
+    end
+
+    it "resets the permalink on each attempt to save when validation fails" do
+      event = Event.new(title: "title a")
+      expect(event.save).to be_falsey
+      expect(event.permalink).to eq("title-a")
+
+      event.title = "title b"
+      expect(event.save).to be_falsey
+      expect(event.permalink).to eq("title-b")
+
+      event.title = "title c"
+      event.description = "not blank"
+      expect(event.save).to be_truthy
+      expect(event.permalink).to eq("title-c")
+
+      event.title = "title d"
+      expect(event.save).to be_truthy
+      expect(event.permalink).to eq("title-c")
+      expect(event.reload.permalink).to eq("title-c")
+    end
+
+
+  end
+
 end

--- a/spec/lib/acts_as_permalink_spec.rb
+++ b/spec/lib/acts_as_permalink_spec.rb
@@ -113,7 +113,7 @@ describe Acts::Permalink do
 
   describe "scope and validation" do
     class Event < ActiveRecord::Base
-      acts_as_permalink
+      acts_as_permalink scope: :owner_id
       validates :description, :title, presence: true
     end
 
@@ -137,7 +137,19 @@ describe Acts::Permalink do
       expect(event.reload.permalink).to eq("title-c")
     end
 
+    it "scopes the uniqueness of the permalink" do
+      expect(Event.create!(description: "a", title: "title", owner_id: 1).permalink).to eq("title")
+      expect(Event.create!(description: "a", title: "title", owner_id: 1).permalink).to eq("title-1")
+      expect(Event.create!(description: "a", title: "title", owner_id: 1).permalink).to eq("title-2")
 
+      expect(Event.create!(description: "a", title: "title", owner_id: 2).permalink).to eq("title")
+      expect(Event.create!(description: "a", title: "title", owner_id: 2).permalink).to eq("title-1")
+
+      expect(Event.create!(description: "a", title: "title", owner_id: nil).permalink).to eq("title")
+      expect(Event.create!(description: "a", title: "title", owner_id: nil).permalink).to eq("title-1")
+
+      expect(Event.create!(description: "a", title: "title", owner_id: 1).permalink).to eq("title-3")
+    end
   end
 
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -8,6 +8,7 @@ describe Acts::Permalink::Config do
     expect(config.from).to eq(:title)
     expect(config.separator).to eq("-")
     expect(config.max_length).to eq(60)
+    expect(config.scope).to be_nil
   end
 
   it "allows the underscore property" do
@@ -33,5 +34,10 @@ describe Acts::Permalink::Config do
     expect(Acts::Permalink::Config.new(max_length: "asdf").max_length).to eq(60)
     expect(Acts::Permalink::Config.new(max_length: 666).max_length).to eq(666)
     expect(Acts::Permalink::Config.new(max_length: "666").max_length).to eq(666)
+  end
+
+  it "does presence on the scope" do
+    expect(Acts::Permalink::Config.new(scope: 1).scope).to eq(1)
+    expect(Acts::Permalink::Config.new(scope: "").scope).to be_nil
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -30,3 +30,10 @@ end
 connection.create_table(:normal_things) do |t|
   t.string :title
 end
+
+connection.create_table(:events) do |t|
+  t.string :title
+  t.string :permalink
+  t.string :description
+  t.integer :owner_id
+end


### PR DESCRIPTION
@garethson

Allows the permalink to be generated with a scope.

The use case is that you have a user logged in and you want to generate say an event permalink, but scoped to their user. If you have a user that creates an event "Birthday" it will have the permalink "birthday", but if a different user creates the event "Birthday" they will generate the permalink "birthday-1" which is unnecessary since the finder will be scoped by user anyway in the controller or whatever:
```ruby
current_user.events.find_by(permalink: params[:permalink]).first
```

Also useful if the model is scoped in the URL:
`/user/123/event/birthday`
`/user/99999/event/birthday`