### PR TITLE
Use Travis CI Docker/container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - "2.0.0"
   - "2.2.1"


### PR DESCRIPTION
@garethson

Now using Docker containers for CI on Travis. 

https://travis-ci.org/kmcphillips/acts_as_permalink/jobs/90119570
```
Using worker: worker-linux-docker-ff48f706.prod.travis-ci.org:travis-linux-8
```

http://docs.travis-ci.com/user/migrating-from-legacy/

Much faster CI now.