### PR TITLE
Allow updating the permalink.

### DIFF
--- a/lib/acts_as_permalink.rb
+++ b/lib/acts_as_permalink.rb
@@ -11,7 +11,10 @@ module Acts
         self.acts_as_permalink_config = Acts::Permalink::Config.new(options)
 
         before_validation :update_permalink, on: :create
-        attr_readonly self.acts_as_permalink_config.to
+
+        unless self.acts_as_permalink_config.allow_update
+          attr_readonly self.acts_as_permalink_config.to
+        end
 
         if self.acts_as_permalink_config.scope
           validates self.acts_as_permalink_config.to, uniqueness: {scope: self.acts_as_permalink_config.scope}

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,7 +1,7 @@
 module Acts
   module Permalink
     class Config
-      attr_reader :to, :from, :separator, :max_length, :scope
+      attr_reader :to, :from, :separator, :max_length, :scope, :allow_update
 
       def initialize(options={})
         @config = options.with_indifferent_access
@@ -13,6 +13,7 @@ module Acts
 
         @max_length = @config[:max_length].to_i rescue 0
         @max_length = 60 unless @max_length > 0
+        @allow_update = !!@config[:allow_update]
       end
     end
   end

--- a/spec/lib/acts_as_permalink_spec.rb
+++ b/spec/lib/acts_as_permalink_spec.rb
@@ -40,11 +40,17 @@ describe Acts::Permalink do
       expect(record.permalink).to_not be_blank
       expect(record.permalink).to match(/^post-\d+$/)
     end
+
+    it "does not allow updating" do
+      record = Post.create!(title: "Test")
+      record.update!(title: "Test2")
+      expect(record.permalink).to eq("test")
+    end
   end
 
   describe "column with some custom properties" do
     class LongThing < ActiveRecord::Base
-      acts_as_permalink max_length: 100, underscore: true
+      acts_as_permalink max_length: 100, underscore: true, allow_update: true
     end
 
     it "adheres to the max_length option even if adding a number for a collision" do
@@ -68,6 +74,13 @@ describe Acts::Permalink do
     it "replaces with an underscore if asked to do so" do
       expect(LongThing.create!(title: "it's an underscore!").permalink).to eq("it_s_an_underscore")
     end
+
+    it "allows updating" do
+      record = LongThing.create!(title: "Test")
+      record.update_attributes(permalink: "live")
+      expect(record.reload.permalink).to eq("live")
+    end
+
   end
 
   describe "single table inheritance" do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -9,10 +9,15 @@ describe Acts::Permalink::Config do
     expect(config.separator).to eq("-")
     expect(config.max_length).to eq(60)
     expect(config.scope).to be_nil
+    expect(config.allow_update).to be_falsy
   end
 
   it "allows the underscore property" do
     expect(Acts::Permalink::Config.new(underscore: true).separator).to eq("_")
+  end
+
+  it "allows the allow_update property" do
+    expect(Acts::Permalink::Config.new(allow_update: true).separator).to be_truthy
   end
 
   it "allows indifferent access" do


### PR DESCRIPTION
Allows updating the permalink.

This isn't that dangerous, as the uniqueness validation is still there, but it does require the consuming code to call `to_permalink` itself, but this at least gives you the option.

To go one level further would be to call scrub the value on save or assignment in this gem, if allowing updates.