### PR TITLE
Matrix Travis CI for ruby and rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: ruby
 sudo: false
+script: bundle exec rspec
 rvm:
   - "2.0.0"
-  - "2.2.1"
-script: bundle exec rspec
+  - "2.2.2"
+  - "2.3.1"
+gemfile:
+  - Gemfile
+  - gemfiles/rails-4.2.gemfile
+matrix:
+  exclude:
+    - rvm: "2.0.0"
+      gemfile: Gemfile

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.2'
+gem 'rack', '< 2.0'


### PR DESCRIPTION
@garethson 

Uses a matrixed Travis CI configuration to deal with the 2.2.2 ruby dependencies on newer versions of rack and rails.